### PR TITLE
Prevent connection pool exhaustion during upserts

### DIFF
--- a/db.py
+++ b/db.py
@@ -539,8 +539,20 @@ def upsert_dataframe(df: pd.DataFrame, table, conflict_cols: list[str], chunk_si
                         if dedupe_size < original_size:
                             log.warning(f"Removed {original_size - dedupe_size} duplicate rows during retry to prevent CardinalityViolation")
 
-                    # Recursively call with much smaller chunks and no connection (will create new transaction)
-                    upsert_dataframe(smaller_df, table, conflict_cols, chunk_size=10, conn=None)
+                    # Iteratively retry the smaller dataframe using the SAME connection
+                    for retry_start in range(0, len(smaller_df), 10):
+                        retry_part = smaller_df.iloc[retry_start:retry_start + 10]
+                        retry_cols = list(retry_part.columns)
+                        retry_records = retry_part.to_dict(orient="records")
+                        if not retry_records:
+                            continue
+                        stmt_retry = insert(table).values(retry_records)
+                        retry_update_cols = {c: getattr(stmt_retry.excluded, c) for c in retry_cols if c not in conflict_cols}
+                        if retry_update_cols:
+                            stmt_retry = stmt_retry.on_conflict_do_update(index_elements=conflict_cols, set_=retry_update_cols)
+                        else:
+                            stmt_retry = stmt_retry.on_conflict_do_nothing(index_elements=conflict_cols)
+                        connection.execute(stmt_retry)
                 else:
                     # Re-raise if it's not a handled issue or if we're already at minimum size
                     raise

--- a/test_connection_pool_fix.py
+++ b/test_connection_pool_fix.py
@@ -1,0 +1,47 @@
+import os
+import pandas as pd
+from sqlalchemy import Column, Integer, create_engine, text
+from sqlalchemy.orm import declarative_base
+from sqlalchemy.pool import QueuePool
+from sqlalchemy.exc import ProgrammingError
+
+# Ensure DATABASE_URL is set before importing db
+os.environ.setdefault("DATABASE_URL", "sqlite://")
+import db
+
+def test_upsert_dataframe_reuses_connection(monkeypatch):
+    # Create engine with a tiny connection pool
+    engine = create_engine("sqlite://", poolclass=QueuePool, pool_size=1, max_overflow=0, pool_timeout=1)
+    monkeypatch.setattr(db, "engine", engine)
+
+    Base = declarative_base()
+
+    class TestTable(Base):
+        __tablename__ = "test_table"
+        id = Column(Integer, primary_key=True)
+        value = Column(Integer)
+
+    Base.metadata.create_all(engine)
+
+    df = pd.DataFrame({"id": [1, 2], "value": [10, 20]})
+
+    with engine.begin() as conn:
+        orig_execute = conn.execute
+        state = {"first": True}
+
+        def flaky(stmt, *args, **kwargs):
+            if state["first"]:
+                state["first"] = False
+                raise ProgrammingError("CardinalityViolation", {}, None)
+            return orig_execute(stmt, *args, **kwargs)
+
+        conn.execute = flaky
+        db.upsert_dataframe(df, TestTable, ["id"], conn=conn)
+
+    # Verify rows inserted
+    with engine.connect() as check_conn:
+        count = check_conn.execute(text("select count(*) from test_table")).scalar()
+    assert count == 2
+
+    # Ensure no connections are left checked out
+    assert engine.pool.checkedout() == 0


### PR DESCRIPTION
## Summary
- Refactor `upsert_dataframe` to retry inserts using the same DB connection and iterative batching instead of recursive calls
- Add regression test to ensure upsert reuses the connection and doesn't leak pool slots

## Testing
- `pytest test_connection_pool_fix.py -q`
- `pytest -q` *(fails: ImportError for `check_data_staleness`, AttributeError in `ValidationResult`, missing `engine` in `data.timescale`, missing `DataLineage` in `db`, module `institutional_ingest` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bb24c992948323bff16b31fd1df0f7