### PR TITLE
Clarify data ingestion service URL

### DIFF
--- a/DEPLOY_TO_RENDER.md
+++ b/DEPLOY_TO_RENDER.md
@@ -161,9 +161,9 @@ alembic upgrade head
 - Verify database connection and basic functionality
 
 #### Check Data Ingestion API Service
-- Test the health endpoint: `https://data-ingestion-service-abcd.onrender.com/health`
-- Verify API endpoints are accessible: `https://data-ingestion-service-abcd.onrender.com/`
-- Test data ingestion: `curl -X POST https://data-ingestion-service-abcd.onrender.com/ingest -H "Content-Type: application/json" -d '{"days": 1}'`
+- Test the health endpoint: `https://data-ingestion-service-se1j.onrender.com/health`
+- Verify API endpoints are accessible: `https://data-ingestion-service-se1j.onrender.com/`
+- Test data ingestion: `curl -X POST https://data-ingestion-service-se1j.onrender.com/ingest -H "Content-Type: application/json" -d '{"days": 1}'`
 
 #### Check Worker Service  
 - Review worker logs for successful startup

--- a/scripts/api_endpoints.py
+++ b/scripts/api_endpoints.py
@@ -64,7 +64,8 @@ def main():
     """Test all API endpoints."""
     if len(sys.argv) != 2:
         print("Usage: python api_endpoints.py <base_url>")
-        print("Example: python api_endpoints.py https://data-ingestion-service-abcd.onrender.com")
+        # Replace with the public URL shown for your Render service
+        print("Example: python api_endpoints.py https://data-ingestion-service-se1j.onrender.com")
         sys.exit(1)
         
     base_url = sys.argv[1]


### PR DESCRIPTION
## Summary
- Document the concrete Render URL for the data-ingestion service
- Update API testing script to show the new URL example

## Testing
- `pytest -q >/tmp/pytest.log && tail -n 2 /tmp/pytest.log`
- `pytest test_api_responsiveness.py::test_mocked_task_responsiveness -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0599bfb008323a50815d32919cf8a