### PR TITLE
Fix feature store persistence and restore feature z-score computation

### DIFF
--- a/features/store.py
+++ b/features/store.py
@@ -54,13 +54,13 @@ class FeatureStore:
     def store_features(self, features_df: pd.DataFrame) -> None:
         if features_df.empty:
             return
-        from db import upsert_dataframe, Feature  # type: ignore
+        from db import Feature, upsert_dataframe  # type: ignore
         features_df = (
             features_df.sort_values('ts')
             .drop_duplicates(['symbol', 'ts'], keep='last')
             .reset_index(drop=True)
         )
-       upsert_dataframe(features_df, Feature, ['symbol','ts'])
+        upsert_dataframe(features_df, Feature, ['symbol', 'ts'])
         log.info(f"Stored {len(features_df)} feature records")
 
     def get_feature_metadata(self, feature_name: str) -> Dict[str, Any]:
@@ -79,7 +79,12 @@ class FeatureStore:
             'tags': feature_def.tags
         }
 
-    def validate_feature_consistency(self, training_features: pd.DataFrame, serving_features: pd.DataFrame, tolerance: float = 1e-6) -> Dict[str, Any]:
+    def validate_feature_consistency(
+        self,
+        training_features: pd.DataFrame,
+        serving_features: pd.DataFrame,
+        tolerance: float = 1e-6,
+    ) -> Dict[str, Any]:
         validation_results = {'consistent': True, 'errors': [], 'warnings': []}
         training_cols = set(training_features.columns)
         serving_cols = set(serving_features.columns)
@@ -131,7 +136,8 @@ class FeatureStore:
             """
             from db import engine  # type: ignore
             prices = pd.read_sql_query(text(price_sql), engine, params=params, parse_dates=['ts'])
-            if prices.empty: return pd.DataFrame()
+            if prices.empty:
+                return pd.DataFrame()
 
             shares_sql = f"""
                 SELECT symbol, as_of, shares

--- a/models/features.py
+++ b/models/features.py
@@ -347,21 +347,23 @@ def build_features(batch_size: int = 200, warmup_days: int = 60) -> pd.DataFrame
             missing_cols = [c for c in features_for_cs if c not in feats.columns]
             for c in missing_cols:
                 feats[c] = np.nan
+
             def _zscore(x: pd.Series) -> pd.Series:
                 m = x.mean()
                 s = x.std(ddof=0)
                 return (x - m) / (s + 1e-8)
+
             # Group by timestamp and apply z‑score; only compute when group size
             # >= 10 to avoid small‑sample noise.  Otherwise fill with NaN.
-            for    for col in features_for_cs:
-        zcol = f'cs_z_{col}'
-        feats[zcol] = feats.groupby('ts')[col].transform(
-            lambda s: _zscore(s) if len(s) >= 10 else pd.Series(np.nan, index=s.index)
-        )
+            for col in features_for_cs:
+                zcol = f'cs_z_{col}'
+                feats[zcol] = feats.groupby('ts')[col].transform(
+                    lambda s: _zscore(s) if len(s) >= 10 else pd.Series(np.nan, index=s.index)
+                )
 
-    upsert_dataframe(feats, Feature, ['symbol', 'ts'])
-    new_rows.append(feats)
-    log.info(f"Batch completed. New rows: {len(feats)}")
+            upsert_dataframe(feats, Feature, ['symbol', 'ts'])
+            new_rows.append(feats)
+            log.info(f"Batch completed. New rows: {len(feats)}")
 
     return pd.concat(new_rows, ignore_index=True) if new_rows else pd.DataFrame()
 


### PR DESCRIPTION
## Summary
- correct the feature store persistence routine to avoid indentation errors and improve validation signature clarity
- repair the cross-sectional z-score loop in the feature builder so features persist with the intended statistics

## Testing
- python -m compileall features/store.py models/features.py

------
https://chatgpt.com/codex/tasks/task_e_68e2bbed1f548323a5dce7860c9c4a7b