### PR TITLE
Handle Polygon API transient errors with retries

### DIFF
--- a/data/universe.py
+++ b/data/universe.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import time
 from datetime import date, datetime
 from typing import Dict, Any, List
 
@@ -58,7 +59,13 @@ def _add_polygon_auth(url: str, api_key: str) -> str:
     return url
 
 
-def _safe_get_json(url: str, params: dict = None, timeout: int = 30) -> dict | None:
+def _safe_get_json(
+    url: str,
+    params: dict = None,
+    timeout: int = 30,
+    retries: int = 3,
+    backoff_factor: float = 0.5,
+) -> dict | None:
     """
     Make a safe HTTP GET request that returns JSON or None on failure.
 
@@ -76,13 +83,36 @@ def _safe_get_json(url: str, params: dict = None, timeout: int = 30) -> dict | N
     dict or None
         The JSON response if successful, None if any error occurs
     """
-    try:
-        resp = requests.get(url, params=params, timeout=timeout)
-        resp.raise_for_status()
-        return resp.json()
-    except Exception as e:
-        log.warning("Request failed for %s: %s", url, str(e))
-        return None
+    attempt = 0
+    while attempt <= retries:
+        try:
+            resp = requests.get(url, params=params, timeout=timeout)
+            resp.raise_for_status()
+            return resp.json()
+        except requests.exceptions.RequestException as exc:
+            status_code = getattr(getattr(exc, "response", None), "status_code", None)
+
+            if status_code is not None and 500 <= status_code < 600 and attempt < retries:
+                sleep_seconds = backoff_factor * (2**attempt)
+                log.warning(
+                    "Request failed for %s with status %s, retrying in %.1fs (attempt %d/%d)",
+                    url,
+                    status_code,
+                    sleep_seconds,
+                    attempt + 1,
+                    retries + 1,
+                )
+                time.sleep(sleep_seconds)
+                attempt += 1
+                continue
+
+            log.warning("Request failed for %s: %s", url, str(exc))
+            return None
+        except Exception as exc:  # pragma: no cover - safety net for unexpected errors
+            log.warning("Unexpected error requesting %s: %s", url, str(exc))
+            return None
+
+    return None
 
 
 def _list_small_cap_symbols(max_market_cap: float = 3_000_000_000.0) -> List[Dict[str, Any]]:


### PR DESCRIPTION
## Summary
- add configurable retry and backoff handling to `_safe_get_json` to better tolerate transient Polygon server errors
- log retry attempts while preserving existing warning and fallback behaviour for unrecoverable failures

## Testing
- pytest test_universe_fix.py -k polygon --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68e2bc8701e48323a656be015afa40b3