### PR TITLE
Fix xgb_ltr objective alias

### DIFF
--- a/models/ml.py
+++ b/models/ml.py
@@ -344,10 +344,14 @@ def _model_specs() -> Dict[str, Pipeline]:
             n_jobs=_xgb_threads(),
             tree_method="hist"
         ))
-        # Always define the LTR model using XGBRegressor with rmse objective.  Using
-        # XGBRanker triggers integer-label constraints which are not met here.
+        # Always define the LTR model using XGBRegressor with a standard regression
+        # objective.  Using XGBRanker triggers integer-label constraints which are not
+        # met here, and XGBoost expects the canonical ``reg:squarederror`` identifier
+        # instead of the legacy ``rmse`` alias.  We still track RMSE as the evaluation
+        # metric to keep reporting consistent with previous runs.
         specs["xgb_ltr"] = _define_pipeline(XGBRegressor(
-            objective='rmse',
+            objective='reg:squarederror',
+            eval_metric='rmse',
             n_estimators=500,
             max_depth=4,
             learning_rate=0.05,


### PR DESCRIPTION
## Summary
- update the xgb_ltr pipeline to use the canonical reg:squarederror objective
- add an explicit rmse eval_metric so reporting remains unchanged
- refresh inline documentation to explain the objective alias change

## Testing
- pytest test_ml_model_configuration.py

------
https://chatgpt.com/codex/tasks/task_e_68e5353c65288323af9cdf147f92079a